### PR TITLE
Using snipcart snippet instead of api call in the footer. I ran in to…

### DIFF
--- a/site/config/config.php
+++ b/site/config/config.php
@@ -16,9 +16,9 @@ for more information: http://getkirby.com/license
 */
 
 c::set('license', 'put your license key here');
-c::set('snipcart_api_key', 'YjdiNWIyOTUtZTIyMy00MWMwLTkwNDUtMzI1M2M2NTgxYjE0')
+c::set('snipcart_api_key', 'your api key here'); /* added semi-colon to end of line and removed default api key 
 
-/*
+
 
 ---------------------------------------
 Kirby Configuration

--- a/site/snippets/footer.php
+++ b/site/snippets/footer.php
@@ -8,10 +8,7 @@
       <a href="http://getkirby.com/made-with-kirby-and-love">Made with Kirby and <b>♥</b></a>
     </div>
 
-    <script type="text/javascript"
-        id="snipcart"
-        src="https://cdn.snipcart.com/scripts/2.0/snipcart.js"
-        data-api-key="<?php echo getenv('snipcart_api_key') ?>"></script>
+    <?php snippet('snipcart') ?> <--! using snipcart snippet instead of hardcoded api script tag -->
 
   </footer>
   </div>

--- a/site/snippets/header.php
+++ b/site/snippets/header.php
@@ -9,13 +9,9 @@
     <meta name="keywords" content="<?php echo $site->keywords()->html() ?>">
 
     <?php echo css('assets/css/main.css') ?>
-    <script
-      src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"
-      type="text/javascript"></script>
 
-    <link id="snipcart-theme" type="text/css"
-        href="https://cdn.snipcart.com/themes/2.0/base/snipcart.min.css"
-        rel="stylesheet">
+    <!-- removed jquery script and snipcart css call here - now called in footer from snipcart snippet -->
+
   </head>
   <body>
     <div class="main-section">


### PR DESCRIPTION
Using snipcart snippet call in the footer instead of api script call in the footer. 

When trying to use the original repo I ran into the problem of trying to change the api in the config file of Kirby as mentioned in the article on the snipcart website and nothing was happening. 

Eventually I realised that the snipcart snippet wasn't being called in the footer at all and was still using the 'hard-coded' API call.

Also added a semi-colon to the end of the set for the api-key in the site config file as that was causing an issue in rendering the site for me.